### PR TITLE
Prevent empty taskbar button

### DIFF
--- a/swing/src/main/java/at/bestsolution/fxembed/swing/FXEmbed.java
+++ b/swing/src/main/java/at/bestsolution/fxembed/swing/FXEmbed.java
@@ -224,15 +224,16 @@ public class FXEmbed extends JComponent {
 			}
 			Platform.runLater(() -> {
 				Stage s = new Stage();
-				s.initStyle(StageStyle.UNDECORATED);
+				//using UTILITY prevents the stage from showing up in the taskbar
+				s.initStyle(StageStyle.UTILITY);
 				Scene sc = new Scene(new Group());
-				consumer.accept(sc);
 				s.setScene(sc);
 				// Make sure the native window is not shown to the user before we reparent it
 				s.setOpacity(0);
 				s.show();
 				long rawHandle = getWindowHandle(s);
 				embedder.setFXHandle(s, rawHandle, false);
+				consumer.accept(sc);
 				embedder.stage = s;
 			});
 		});

--- a/swing/src/main/java/at/bestsolution/fxembed/swing/FXEmbed.java
+++ b/swing/src/main/java/at/bestsolution/fxembed/swing/FXEmbed.java
@@ -227,7 +227,6 @@ public class FXEmbed extends JComponent {
 				//using UTILITY prevents the stage from showing up in the taskbar
 				s.initStyle(StageStyle.UTILITY);
 				Scene sc = new Scene(new Group());
-				s.setScene(sc);
 				// Make sure the native window is not shown to the user before we reparent it
 				s.setOpacity(0);
 				s.show();
@@ -235,6 +234,11 @@ public class FXEmbed extends JComponent {
 				embedder.setFXHandle(s, rawHandle, false);
 				consumer.accept(sc);
 				embedder.stage = s;
+				/*
+				 * the scene must be put into the stage only after reparenting,
+				 * otherwise popups will appear a few pixels too low (as if a window title bar was there) 
+				 */
+				s.setScene(sc);
 			});
 		});
 		t.start();


### PR DESCRIPTION
Using a different StageStyle (i.e. UTILITY instead of UNDECORATED) seems to be the best choice for our case (see also https://bugs.openjdk.java.net/browse/JDK-8091566). Additionally, it is better to run the scene consumer after the reparenting has happened, because we do not have control on how long it could take or other side effects of such client code.

Fixes #15 